### PR TITLE
Fix attribution destination parameter in specification

### DIFF
--- a/AttributionReporting/MeasurementAdTechServerSpec/measurement_adtech_server_spec.json
+++ b/AttributionReporting/MeasurementAdTechServerSpec/measurement_adtech_server_spec.json
@@ -129,7 +129,7 @@
             "EventReport": {
                 "type": "object",
                 "properties": {
-                    "attribution-destination": {
+                    "attribution_destination": {
                         "type": "string"
                     },
                     "source_event_id": {


### PR DESCRIPTION
The code requires attribution destination to be with underscore https://github.com/android/privacy-sandbox-samples/blob/main/AttributionReporting/MeasurementAdTechServer/src/main/kotlin/com/example/samples/measurement/server/entities/EventReport.kt#L24-L26