### PR TITLE
Configurable source and trigger endpoints

### DIFF
--- a/AttributionReporting/MeasurementSampleApp/app/src/main/java/com/example/measurement/sampleapp/di/module/AppModule.kt
+++ b/AttributionReporting/MeasurementSampleApp/app/src/main/java/com/example/measurement/sampleapp/di/module/AppModule.kt
@@ -24,7 +24,8 @@ import dagger.Provides
 /*
 * Default values
 * */
-var DEFAULT_SERVER_URL  = "https://measurement.sample.server.url.com"
+var DEFAULT_SERVER_SOURCE_URL  = "https://measurement.sample.server.url.com/source"
+var DEFAULT_SERVER_TRIGGER_URL  = "https://measurement.sample.server.url.com/trigger"
 var DEFAULT_SOURCE_REGISTRATION_ID = "1"
 var DEFAULT_CONVERSION_REGISTRATION_ID = "1"
 

--- a/AttributionReporting/MeasurementSampleApp/app/src/main/java/com/example/measurement/sampleapp/view/MainActivity.kt
+++ b/AttributionReporting/MeasurementSampleApp/app/src/main/java/com/example/measurement/sampleapp/view/MainActivity.kt
@@ -71,8 +71,10 @@ class MainActivity : BaseActivity() {
   }
 
   override fun onOptionsItemSelected(item: MenuItem): Boolean {
-    if (item.itemId == R.id.menu_server_url) {
-      showServerUrlDialog()
+    if (item.itemId == R.id.menu_server_source_url) {
+      showServerSourceUrlDialog()
+    } else if (item.itemId == R.id.menu_server_trigger_url) {
+      showServerTriggerUrlDialog()
     }
     return super.onOptionsItemSelected(item)
   }
@@ -81,13 +83,25 @@ class MainActivity : BaseActivity() {
   * showServerUrlDialog
   * This method shows a dialog in which the server url is configurable
   * */
-  private fun showServerUrlDialog(){
-    val editText = EditText(this).apply { setText(mainViewModel.getServerUrl()) }
+  private fun showServerSourceUrlDialog(){
+    val editText = EditText(this).apply { setText(mainViewModel.getServerSourceUrl()) }
     val alert = AlertDialog.Builder(this).apply {
-     setTitle(R.string.server_url)
+     setTitle(R.string.server_source_url)
      setView(editText)
      setPositiveButton(R.string.save) { _, _ ->
-        mainViewModel.setServerUrl(editText.text.toString())
+        mainViewModel.setServerSourceUrl(editText.text.toString())
+      }
+    }
+    alert.show()
+  }
+
+  private fun showServerTriggerUrlDialog(){
+    val editText = EditText(this).apply { setText(mainViewModel.getServerTriggerUrl()) }
+    val alert = AlertDialog.Builder(this).apply {
+      setTitle(R.string.server_trigger_url)
+      setView(editText)
+      setPositiveButton(R.string.save) { _, _ ->
+        mainViewModel.setServerTriggerUrl(editText.text.toString())
       }
     }
     alert.show()

--- a/AttributionReporting/MeasurementSampleApp/app/src/main/java/com/example/measurement/sampleapp/view/SourceFragment.kt
+++ b/AttributionReporting/MeasurementSampleApp/app/src/main/java/com/example/measurement/sampleapp/view/SourceFragment.kt
@@ -67,14 +67,14 @@ class SourceFragment : BaseFragment() {
 
     binding.registerCtcButton.setOnTouchListener { _, event ->
       if (event.action == MotionEvent.ACTION_DOWN) {
-        measurementViewModel.registerSource(event, mainViewModel.getServerUrl(), mainViewModel.getSourceRegistrationId())
+        measurementViewModel.registerSource(event, mainViewModel.getServerSourceUrl(), mainViewModel.getSourceRegistrationId())
         Toast.makeText(requireContext(), R.string.registering, Toast.LENGTH_SHORT).show()
       }
       false
     }
 
     binding.registerVtcButton.setOnClickListener {
-      measurementViewModel.registerSource(null,  mainViewModel.getServerUrl(), mainViewModel.getSourceRegistrationId())
+      measurementViewModel.registerSource(null, mainViewModel.getServerSourceUrl(), mainViewModel.getSourceRegistrationId())
     }
     return binding.root
   }

--- a/AttributionReporting/MeasurementSampleApp/app/src/main/java/com/example/measurement/sampleapp/view/TriggerFragment.kt
+++ b/AttributionReporting/MeasurementSampleApp/app/src/main/java/com/example/measurement/sampleapp/view/TriggerFragment.kt
@@ -57,7 +57,7 @@ class TriggerFragment : BaseFragment() {
     binding.triggerConvIdInput.doOnTextChanged { text, _,_,_ -> mainViewModel.setConvId(text.toString()) }
 
     binding.registerTriggerButton.setOnClickListener {
-      measurementViewModel.registerTrigger(mainViewModel.getServerUrl(), mainViewModel.getConversionRegistrationId())
+      measurementViewModel.registerTrigger(mainViewModel.getServerTriggerUrl(), mainViewModel.getConversionRegistrationId())
       Toast.makeText(requireContext(), R.string.registering, Toast.LENGTH_SHORT).show()
     }
 

--- a/AttributionReporting/MeasurementSampleApp/app/src/main/java/com/example/measurement/sampleapp/viewmodel/MainViewModel.kt
+++ b/AttributionReporting/MeasurementSampleApp/app/src/main/java/com/example/measurement/sampleapp/viewmodel/MainViewModel.kt
@@ -25,12 +25,11 @@ import androidx.datastore.preferences.preferencesDataStore
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.measurement.sampleapp.di.module.DEFAULT_CONVERSION_REGISTRATION_ID
-import com.example.measurement.sampleapp.di.module.DEFAULT_SERVER_URL
+import com.example.measurement.sampleapp.di.module.DEFAULT_SERVER_SOURCE_URL
+import com.example.measurement.sampleapp.di.module.DEFAULT_SERVER_TRIGGER_URL
 import com.example.measurement.sampleapp.di.module.DEFAULT_SOURCE_REGISTRATION_ID
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -40,7 +39,8 @@ import kotlinx.coroutines.runBlocking
 /*
 * Datastore Keys
 * */
-private const val DATASTORE_KEY_SERVER_URL = "DATASTORE_KEY_SERVER_URL"
+private const val DATASTORE_KEY_SERVER_SOURCE_URL = "DATASTORE_KEY_SERVER_SOURCE_URL"
+private const val DATASTORE_KEY_SERVER_TRIGGER_URL = "DATASTORE_KEY_SERVER_TRIGGER_URL"
 private const val DATASTORE_KEY_SOURCE_REGISTRATION_ID = "DATASTORE_KEY_SOURCE_REGISTRATION_ID"
 private const val DATASTORE_KEY_CONVERSION_REGISTRATION_ID= "DATASTORE_KEY_CONVERSION_REGISTRATION_ID"
 
@@ -58,28 +58,44 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
 * */
 class MainViewModel @Inject constructor(application: Application) : AndroidViewModel(application) {
 
-  /*
-  * These are methods to read and write to local storage.
-  * */
-  
-     fun setServerUrl(serverUrl: String) {
-       viewModelScope.launch {
-        getApplication<Application>().applicationContext.dataStore.edit { preferences ->
-          preferences[stringPreferencesKey(DATASTORE_KEY_SERVER_URL)] = serverUrl
-        }
+   /*
+   * These are methods to read and write to local storage.
+   * */
+   fun setServerSourceUrl(serverSourceUrl: String) {
+     viewModelScope.launch {
+      getApplication<Application>().applicationContext.dataStore.edit { preferences ->
+        preferences[stringPreferencesKey(DATASTORE_KEY_SERVER_SOURCE_URL)] = serverSourceUrl
       }
-     }
+    }
+   }
 
-   fun getServerUrl(): String {
-     val serverUrl : String
+   fun getServerSourceUrl(): String {
+     val serverSourceUrl : String
      runBlocking(Dispatchers.IO){
-      serverUrl = getApplication<Application>().applicationContext.dataStore.data.map { preferences ->
-        preferences[stringPreferencesKey(DATASTORE_KEY_SERVER_URL)] ?: DEFAULT_SERVER_URL
+       serverSourceUrl = getApplication<Application>().applicationContext.dataStore.data.map { preferences ->
+        preferences[stringPreferencesKey(DATASTORE_KEY_SERVER_SOURCE_URL)] ?: DEFAULT_SERVER_SOURCE_URL
       }.first()
     }
-     return serverUrl
+     return serverSourceUrl
   }
-  
+
+  fun setServerTriggerUrl(serverTriggerUrl: String) {
+    viewModelScope.launch {
+      getApplication<Application>().applicationContext.dataStore.edit { preferences ->
+        preferences[stringPreferencesKey(DATASTORE_KEY_SERVER_TRIGGER_URL)] = serverTriggerUrl
+      }
+    }
+  }
+
+  fun getServerTriggerUrl(): String {
+    val serverTriggerUrl : String
+    runBlocking(Dispatchers.IO){
+      serverTriggerUrl = getApplication<Application>().applicationContext.dataStore.data.map { preferences ->
+        preferences[stringPreferencesKey(DATASTORE_KEY_SERVER_TRIGGER_URL)] ?: DEFAULT_SERVER_TRIGGER_URL
+      }.first()
+    }
+    return serverTriggerUrl
+  }
 
   fun setSourceRegistrationId(sourceRegistrationId: String) {
     viewModelScope.launch {

--- a/AttributionReporting/MeasurementSampleApp/app/src/main/java/com/example/measurement/sampleapp/viewmodel/MeasurementViewModel.kt
+++ b/AttributionReporting/MeasurementSampleApp/app/src/main/java/com/example/measurement/sampleapp/viewmodel/MeasurementViewModel.kt
@@ -41,7 +41,7 @@ class MeasurementViewModel @Inject constructor(private val measurementManager: M
       Log.d("adservices", "registerSource")
       viewModelScope.launch(Dispatchers.Main) {
           async {
-              measurementManager.registerSource(Uri.parse("$serverUrl/source?ad_id=$adId"),
+              measurementManager.registerSource(Uri.parse("$serverUrl?ad_id=$adId"),
                   inputEvent)
           }
       }
@@ -56,7 +56,7 @@ class MeasurementViewModel @Inject constructor(private val measurementManager: M
       viewModelScope.launch(Dispatchers.Main) {
           async {
               measurementManager.registerTrigger(
-                  Uri.parse("$serverUrl/trigger?conv_id=$convId"))
+                  Uri.parse("$serverUrl?conv_id=$convId"))
           }
       }
   }

--- a/AttributionReporting/MeasurementSampleApp/app/src/main/res/menu/menu.xml
+++ b/AttributionReporting/MeasurementSampleApp/app/src/main/res/menu/menu.xml
@@ -14,9 +14,13 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
   <item
-      android:id="@+id/menu_server_url"
+      android:id="@+id/menu_server_source_url"
       android:orderInCategory="100"
-      android:title="@string/server_url"
+      android:title="@string/server_source_url"
       app:showAsAction="never" />
-
+  <item
+      android:id="@+id/menu_server_trigger_url"
+      android:orderInCategory="100"
+      android:title="@string/server_trigger_url"
+      app:showAsAction="never" />
 </menu>

--- a/AttributionReporting/MeasurementSampleApp/app/src/main/res/values/strings.xml
+++ b/AttributionReporting/MeasurementSampleApp/app/src/main/res/values/strings.xml
@@ -21,7 +21,8 @@
   <string name="register_trigger_conv_id">Conversion Registration ID</string>
   <string name="register_trigger">Register Trigger</string>
   <string name="error_message">Please use the latest Privacy Sandbox on Android Developer Preview.</string>
-  <string name="server_url">Server URL</string>
+  <string name="server_source_url">Server Source URL</string>
+  <string name="server_trigger_url">Server Trigger URL</string>
   <string name="save">Save</string>
   <string name="ad_view_text_ctc">This is a Sample Ad. CLICK TO REGISTER</string>
   <string name="ad_view_text_vtc">This is a Sample Ad. VIEW TO REGISTER</string>


### PR DESCRIPTION
The server source and trigger endpoints were hardcoded to /source and /trigger. These endpoints can be configured differently. This change splits the Server URL into Source and Trigger URL and removes the hardcoded value.

These changes are a cherry-pick from a537362125161c418168405c42d056a70be3bfc5. Same changes as in https://github.com/android/privacy-sandbox-samples/pull/58