### PR TITLE
Updated for FLEDGE name change

### DIFF
--- a/Fledge/README.md
+++ b/Fledge/README.md
@@ -1,5 +1,7 @@
-FLEDGE Samples
+Protected Audience API Samples
 ----------
+
+FLEDGE has been renamed to Protected Audience API. To learn more about the name change, see the [blog post](https://privacysandbox.com/intl/en_us/news/protected-audience-api-our-new-name-for-fledge)
 
 * **[FledgeKotlin](FledgeKotlin)** (Kotlin) - Demonstrates how to initialize and call the FLEDGE APIs.
 


### PR DESCRIPTION
FLEDGE has been renamed to Protected Audience API. To learn more about the name change, see the [blog post](https://privacysandbox.com/intl/en_us/news/protected-audience-api-our-new-name-for-fledge)