### PR TITLE
Fix: Remove thread blocking logic from SdkProvider implementation

### DIFF
--- a/PrivacySandboxKotlin/mediatee-sdk-adapter/src/main/java/com/mediateeadapter/implementation/SdkProvider.kt
+++ b/PrivacySandboxKotlin/mediatee-sdk-adapter/src/main/java/com/mediateeadapter/implementation/SdkProvider.kt
@@ -68,10 +68,14 @@ class SdkProvider : AbstractSandboxedSdkProviderCompat() {
         // mediateeSdk is loaded before the adapter loadSdk call is made, so it should be present
         // in already loaded sdks.
         for (loadedSandboxedSdk in controller.getSandboxedSdks()) {
-            if (mediatorSdk == null && loadedSandboxedSdk.getSdkInfo()?.name == mediatorSdkName) {
+            val needToLoadMediator =
+                mediatorSdk == null && loadedSandboxedSdk.getSdkInfo()?.name == mediatorSdkName
+            val needToLoadMediatee =
+                mediateeSdk == null && loadedSandboxedSdk.getSdkInfo()?.name == mediateeSdkName
+            if (needToLoadMediator) {
                 mediatorSdk = loadedSandboxedSdk
             }
-            if (mediateeSdk == null && loadedSandboxedSdk.getSdkInfo()?.name == mediateeSdkName) {
+            if (needToLoadMediatee) {
                 mediateeSdk = loadedSandboxedSdk
             }
             if (mediatorSdk != null && mediateeSdk != null) {

--- a/PrivacySandboxKotlin/runtime-aware-sdk/src/main/java/com/runtimeaware/sdk/ExistingSdk.kt
+++ b/PrivacySandboxKotlin/runtime-aware-sdk/src/main/java/com/runtimeaware/sdk/ExistingSdk.kt
@@ -80,6 +80,8 @@ class ExistingSdk(private val context: Context) {
 
                 val sandboxedSdk = sandboxManagerCompat.loadSdk(SDK_NAME, Bundle.EMPTY)
                 remoteInstance = SdkServiceFactory.wrapToSdkService(sandboxedSdk.getInterface()!!)
+                // Initialise Adapters and Mediatees.
+                remoteInstance?.initialise()
                 return remoteInstance
             } catch (e: LoadSdkCompatException) {
                 Log.e(TAG, "Failed to load SDK, error code: ${e.loadSdkErrorCode}", e)

--- a/PrivacySandboxKotlin/runtime-enabled-sdk/src/main/java/com/runtimeenabled/api/SdkService.kt
+++ b/PrivacySandboxKotlin/runtime-enabled-sdk/src/main/java/com/runtimeenabled/api/SdkService.kt
@@ -21,10 +21,7 @@ import androidx.privacysandbox.tools.PrivacySandboxService
 @PrivacySandboxService
 interface SdkService {
 
-    /**
-     * App has to call this API after loadSdk("mediator") call.
-     * Mediatee and Adapter SDKs are loaded by the Mediator when this API is called.
-     */
+    /** Loads Mediatee and Adapter SDKs. */
     suspend fun initialise()
 
     suspend fun getMessage(): String

--- a/PrivacySandboxKotlin/runtime-enabled-sdk/src/main/java/com/runtimeenabled/api/SdkService.kt
+++ b/PrivacySandboxKotlin/runtime-enabled-sdk/src/main/java/com/runtimeenabled/api/SdkService.kt
@@ -20,6 +20,13 @@ import androidx.privacysandbox.tools.PrivacySandboxService
 
 @PrivacySandboxService
 interface SdkService {
+
+    /**
+     * App has to call this API after loadSdk("mediator") call.
+     * Mediatee and Adapter SDKs are loaded by the Mediator when this API is called.
+     */
+    suspend fun initialise()
+
     suspend fun getMessage(): String
 
     suspend fun createFile(sizeInMb: Int): String

--- a/PrivacySandboxKotlin/runtime-enabled-sdk/src/main/java/com/runtimeenabled/implementation/SdkProvider.kt
+++ b/PrivacySandboxKotlin/runtime-enabled-sdk/src/main/java/com/runtimeenabled/implementation/SdkProvider.kt
@@ -16,22 +16,11 @@
 package com.runtimeenabled.implementation
 
 import android.content.Context
-import android.os.Bundle
-import androidx.privacysandbox.sdkruntime.core.SandboxedSdkCompat
-import androidx.privacysandbox.sdkruntime.core.controller.SdkSandboxControllerCompat
 import com.runtimeenabled.api.AbstractSandboxedSdkProviderCompat
 import com.runtimeenabled.api.SdkService
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 /** Provides an [SdkService] implementation when the SDK is loaded. */
 class SdkProvider : AbstractSandboxedSdkProviderCompat() {
-
-    private val adapterSdkName = "com.mediateeadapter.sdk"
-
-    private val coroutineScope = CoroutineScope(Dispatchers.Main)
-
     /**
      * Returns the [SdkService] implementation. Called when the SDK is loaded.
      *
@@ -39,24 +28,4 @@ class SdkProvider : AbstractSandboxedSdkProviderCompat() {
      * the Privacy Sandbox API Compiler plugin as the entry point for the app/SDK communication.
      */
     override fun createSdkService(context: Context): SdkService = SdkServiceImpl(context)
-
-    /**
-     * Does the work needed for the SDK to start handling requests. SDK should do any work to be
-     * ready to handle upcoming requests.
-     *
-     * This function is called by the SDK sandbox after it loads the SDK.
-     *
-     * Mediator initialises the Runtime-enabled adapters in its own initialisation call.
-     */
-    override fun onLoadSdk(params: Bundle): SandboxedSdkCompat {
-        coroutineScope.launch {
-            initialiseAdapters()
-        }
-        return super.onLoadSdk(params)
-    }
-
-    private suspend fun initialiseAdapters() {
-        SdkSandboxControllerCompat.from(checkNotNull(context) { "Cannot initialise adapters!" })
-            .loadSdk(adapterSdkName, Bundle.EMPTY)
-    }
 }

--- a/PrivacySandboxKotlin/runtime-enabled-sdk/src/main/java/com/runtimeenabled/implementation/SdkServiceImpl.kt
+++ b/PrivacySandboxKotlin/runtime-enabled-sdk/src/main/java/com/runtimeenabled/implementation/SdkServiceImpl.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import android.os.Bundle
 import android.os.RemoteException
 import android.util.Log
+import androidx.privacysandbox.sdkruntime.core.controller.SdkSandboxControllerCompat
 import androidx.privacysandbox.ui.client.SandboxedUiAdapterFactory
 import com.runtimeenabled.R
 import com.runtimeenabled.api.FullscreenAd
@@ -37,12 +38,22 @@ import androidx.privacysandbox.ui.provider.toCoreLibInfo
 import com.runtimeenabled.api.MediateeAdapterInterface
 
 class SdkServiceImpl(private val context: Context) : SdkService {
-    override suspend fun getMessage(): String = "Hello from Privacy Sandbox!"
 
     private var inAppMediateeAdapter: MediateeAdapterInterface? = null
     private var mediateeAdapter: MediateeAdapterInterface? = null
-  
+
+    private val adapterSdkName = "com.mediateeadapter.sdk"
+    private val mediateeSdkName = "com.mediatee.sdk"
     private val tag = "ExampleSdk"
+
+    override suspend fun initialise() {
+        val sandboxController = SdkSandboxControllerCompat.from(context)
+        sandboxController.loadSdk(mediateeSdkName, Bundle.EMPTY)
+        // Adapter should only be loaded after Mediatee is loaded.
+        sandboxController.loadSdk(adapterSdkName, Bundle.EMPTY)
+    }
+
+    override suspend fun getMessage(): String = "Hello from Privacy Sandbox!"
 
     override suspend fun createFile(sizeInMb: Int): String {
         val path = Paths.get(

--- a/PrivacySandboxKotlin/runtime-enabled-sdk/src/main/java/com/runtimeenabled/implementation/SdkServiceImpl.kt
+++ b/PrivacySandboxKotlin/runtime-enabled-sdk/src/main/java/com/runtimeenabled/implementation/SdkServiceImpl.kt
@@ -44,7 +44,7 @@ class SdkServiceImpl(private val context: Context) : SdkService {
 
     private val adapterSdkName = "com.mediateeadapter.sdk"
     private val mediateeSdkName = "com.mediatee.sdk"
-    private val tag = "ExampleSdk"
+    private val tag = "RuntimeEnabledSdk"
 
     override suspend fun initialise() {
         val sandboxController = SdkSandboxControllerCompat.from(context)

--- a/PrivacySandboxKotlin/runtime-enabled-sdk/src/main/java/com/runtimeenabled/implementation/SdkServiceImpl.kt
+++ b/PrivacySandboxKotlin/runtime-enabled-sdk/src/main/java/com/runtimeenabled/implementation/SdkServiceImpl.kt
@@ -53,7 +53,7 @@ class SdkServiceImpl(private val context: Context) : SdkService {
         sandboxController.loadSdk(adapterSdkName, Bundle.EMPTY)
     }
 
-    override suspend fun getMessage(): String = "Hello from Privacy Sandbox!"
+    override suspend fun getMessage(): String = "Hello from Runtime-enabled SDK!"
 
     override suspend fun createFile(sizeInMb: Int): String {
         val path = Paths.get(


### PR DESCRIPTION
- Thread blocking code removed from SdkProvider implementation and added to a new initialise API in mediator (runtime-enabled-sdk).
- RA_SDK (runtime-aware-sdk) will call both SdkSandboxController#loadSdk("mediatorsdk") and mediatorSdkService.initialise(). This will be done by the App in the long term.