### PR TITLE
Added gradle properties warning to update libs.versions.toml

### DIFF
--- a/PrivacySandboxKotlin/gradle/libs.versions.toml
+++ b/PrivacySandboxKotlin/gradle/libs.versions.toml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 [versions]
+# If you change any of these, make sure to replace them on gradle.properties
 kotlin = "1.9.10"
 ksp = "1.9.10-1.0.13"
 agp = "8.7.2"

--- a/PrivacySandboxKotlin/gradle/libs.versions.toml
+++ b/PrivacySandboxKotlin/gradle/libs.versions.toml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 [versions]
-# If you change any of these, make sure to replace them on gradle.properties
+# If you update your kotlin, coroutines,
+# or SDK Runtime Jetpack library versions (Shim tools, Backcompat sdkrt, ui, activity),
+# make sure to also update the dependencies specified in `gradle.properties`.
 kotlin = "1.9.10"
 ksp = "1.9.10-1.0.13"
 agp = "8.7.2"


### PR DESCRIPTION
There's currently no warning that would alert developers that there's a requirement to manually change the dependencies for the AGP plugin on gradle.properties. Adding this warning to potentially prevent some pain.