### PR TITLE
fix(deps): Fixes dependency mismatch with Jeptack 2025 Kotlin 2.0+ requirement

### DIFF
--- a/PrivacySandboxKotlin/gradle.properties
+++ b/PrivacySandboxKotlin/gradle.properties
@@ -44,8 +44,8 @@ android.privacySandboxSdk.apiPackager=androidx.privacysandbox.tools:tools:1.0.0-
   androidx.privacysandbox.tools:tools-apipackager:1.0.0-alpha13
 android.privacySandboxSdk.apiGenerator.generatedRuntimeDependencies=\
   androidx.privacysandbox.tools:tools-apigenerator:1.0.0-alpha13,\
-  org.jetbrains.kotlin:kotlin-stdlib:1.9.10,\
-  org.jetbrains.kotlinx:kotlinx-coroutines-android:1.0.1,\
+  org.jetbrains.kotlin:kotlin-stdlib:2.1.10,\
+  org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3,\
   androidx.privacysandbox.activity:activity-core:1.0.0-alpha02,\
   androidx.privacysandbox.activity:activity-client:1.0.0-alpha02,\
   androidx.privacysandbox.activity:activity-provider:1.0.0-alpha02,\

--- a/PrivacySandboxKotlin/gradle/libs.versions.toml
+++ b/PrivacySandboxKotlin/gradle/libs.versions.toml
@@ -16,22 +16,22 @@
 # If you update your kotlin, coroutines,
 # or SDK Runtime Jetpack library versions (Shim tools, Backcompat sdkrt, ui, activity),
 # make sure to also update the dependencies specified in `gradle.properties`.
-kotlin = "1.9.10"
-ksp = "1.9.10-1.0.13"
-agp = "8.7.2"
+kotlin = "2.1.20"
+ksp = "2.1.20-1.0.31"
+agp = "8.9.2"
 privacySandboxBuildPlugin = "1.0.0-alpha02"
 sdkRuntimeBackcompat = "1.0.0-alpha17"
 sdkRuntimeShim = "1.0.0-alpha13"
 sdkRuntimeUi = "1.0.0-alpha15"
 sdkRuntimeActivity = "1.0.0-alpha02"
 appcompat = "1.7.0"
-material = "1.9.0"
-activityKtx = "1.9.0"
-lifecycleCommon = "2.7.0"
-coroutines = "1.7.1"
-annotation = "1.6.0"
-kotlinStdlibJdk8 = "1.9.10"
-androidxTestRunner = "1.5.2"
+material = "1.12.0"
+activityKtx = "1.10.1"
+lifecycleCommon = "2.8.7"
+coroutines = "1.7.3"
+annotation = "1.9.1"
+kotlinStdlibJdk8 = "2.1.10"
+androidxTestRunner = "1.6.2"
 
 [libraries]
 # Plugins

--- a/PrivacySandboxKotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/PrivacySandboxKotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Jun 10 16:28:22 UTC 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/PrivacySandboxKotlin/inapp-mediatee-sdk-adapter/src/main/java/com/inappmediateeadapter/implementation/InAppAdViewSandboxedUiAdapter.kt
+++ b/PrivacySandboxKotlin/inapp-mediatee-sdk-adapter/src/main/java/com/inappmediateeadapter/implementation/InAppAdViewSandboxedUiAdapter.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
 import android.os.IBinder
 import android.view.View
 import androidx.privacysandbox.ui.core.SandboxedUiAdapter
-import androidx.privacysandbox.ui.core.SessionConstants
+import androidx.privacysandbox.ui.core.SessionData
 import androidx.privacysandbox.ui.provider.AbstractSandboxedUiAdapter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -28,7 +28,7 @@ class InAppAdViewSandboxedUiAdapter(private val mediateeAdView: View):
      * We consider the client the owner of the SandboxedSdkView.
      *
      @param context The client's context.
-     * @param sessionConstants Constants related to the session, such as the presentation id.
+     * @param sessionData Constants related to the session, such as the presentation id.
      * @param initialWidth The initial width of the adapter's view.
      * @param initialHeight The initial height of the adapter's view.
      * @param isZOrderOnTop Whether the session's view should be drawn on top of other views.
@@ -37,7 +37,7 @@ class InAppAdViewSandboxedUiAdapter(private val mediateeAdView: View):
      */
     override fun openSession(
         context: Context,
-        sessionConstants: SessionConstants,
+        sessionData: SessionData,
         initialWidth: Int,
         initialHeight: Int,
         isZOrderOnTop: Boolean,

--- a/PrivacySandboxKotlin/mediatee-sdk-adapter/build.gradle
+++ b/PrivacySandboxKotlin/mediatee-sdk-adapter/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation libs.androidx.lifecycle.common
     implementation libs.bundles.coroutines
     implementation libs.bundles.sdkruntimeRESDK
+    implementation libs.sdkruntime.ui.client
     ksp libs.androidx.annotation
     ksp libs.sdkruntime.tools.apicompiler
 }

--- a/PrivacySandboxKotlin/mediatee-sdk/src/main/java/com/mediatee/implementation/SdkSandboxedUiAdapterImpl.kt
+++ b/PrivacySandboxKotlin/mediatee-sdk/src/main/java/com/mediatee/implementation/SdkSandboxedUiAdapterImpl.kt
@@ -18,13 +18,11 @@ package com.mediatee.implementation
 import android.content.Context
 import android.content.res.Configuration
 import android.os.Bundle
-import android.os.IBinder
 import android.view.View
 import android.webkit.WebView
 import android.widget.TextView
 import androidx.privacysandbox.ui.core.SandboxedUiAdapter
-import androidx.privacysandbox.ui.core.SessionConstants
-import androidx.privacysandbox.ui.core.SessionObserverFactory
+import androidx.privacysandbox.ui.core.SessionData
 import com.mediatee.api.SdkBannerRequest
 import com.mediatee.api.SdkSandboxedUiAdapter
 import kotlinx.coroutines.CoroutineScope
@@ -44,7 +42,7 @@ class SdkSandboxedUiAdapterImpl(
      * We consider the client the owner of the SandboxedSdkView.
      *
      @param context The client's context.
-     * @param sessionConstants Constants related to the session, such as the presentation id.
+     * @param sessionData Constants related to the session, such as the presentation id.
      * @param initialWidth The initial width of the adapter's view.
      * @param initialHeight The initial height of the adapter's view.
      * @param isZOrderOnTop Whether the session's view should be drawn on top of other views.
@@ -53,7 +51,7 @@ class SdkSandboxedUiAdapterImpl(
      */
     override fun openSession(
         context: Context,
-        sessionConstants: SessionConstants,
+        sessionData: SessionData,
         initialWidth: Int,
         initialHeight: Int,
         isZOrderOnTop: Boolean,
@@ -109,6 +107,10 @@ private class SdkUiSession(
 
     override fun notifyResized(width: Int, height: Int) {
         // Notifies that the size of the presentation area in the app has changed.
+    }
+
+    override fun notifySessionRendered(supportedSignalOptions: Set<String>) {
+        TODO("Not yet implemented")
     }
 
     override fun notifyUiChanged(uiContainerInfo: Bundle) {

--- a/PrivacySandboxKotlin/runtime-aware-sdk/src/main/java/com/runtimeaware/sdk/BannerAd.kt
+++ b/PrivacySandboxKotlin/runtime-aware-sdk/src/main/java/com/runtimeaware/sdk/BannerAd.kt
@@ -21,7 +21,7 @@ import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-import androidx.privacysandbox.activity.client.createSdkActivityLauncher
+import androidx.privacysandbox.activity.client.createManagedSdkActivityLauncher
 import androidx.privacysandbox.ui.client.SandboxedUiAdapterFactory
 import androidx.privacysandbox.ui.client.view.SandboxedSdkView
 import androidx.privacysandbox.ui.core.SandboxedUiAdapter
@@ -68,7 +68,7 @@ class BannerAd(context: Context, attrs: AttributeSet) : LinearLayout(context, at
             return null
         }
 
-        val launcher = baseActivity.createSdkActivityLauncher(allowSdkActivityLaunch)
+        val launcher = baseActivity.createManagedSdkActivityLauncher(allowSdkActivityLaunch)
         val request = SdkBannerRequest(message, launcher, shouldLoadWebView)
         // Get the SandboxedUiAdapter from the Bundle.
         return SandboxedUiAdapterFactory.createFromCoreLibInfo(

--- a/PrivacySandboxKotlin/runtime-aware-sdk/src/main/java/com/runtimeaware/sdk/FullscreenAd.kt
+++ b/PrivacySandboxKotlin/runtime-aware-sdk/src/main/java/com/runtimeaware/sdk/FullscreenAd.kt
@@ -19,12 +19,12 @@ import android.content.Context
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import com.runtimeenabled.api.FullscreenAd
-import androidx.privacysandbox.activity.client.createSdkActivityLauncher
+import androidx.privacysandbox.activity.client.createManagedSdkActivityLauncher
 import androidx.privacysandbox.activity.core.SdkActivityLauncher
 
 class FullscreenAd(private val sdkFullscreenAd: FullscreenAd) {
     suspend fun show(baseActivity: AppCompatActivity, allowSdkActivityLaunch: () -> Boolean) {
-        val activityLauncher = baseActivity.createSdkActivityLauncher(allowSdkActivityLaunch)
+        val activityLauncher = baseActivity.createManagedSdkActivityLauncher(allowSdkActivityLaunch)
         sdkFullscreenAd.show(activityLauncher)
     }
 

--- a/PrivacySandboxKotlin/runtime-enabled-sdk/src/main/java/com/runtimeenabled/implementation/SdkSandboxedUiAdapterImpl.kt
+++ b/PrivacySandboxKotlin/runtime-enabled-sdk/src/main/java/com/runtimeenabled/implementation/SdkSandboxedUiAdapterImpl.kt
@@ -29,7 +29,7 @@ import androidx.privacysandbox.sdkruntime.core.controller.SdkSandboxControllerCo
 import androidx.privacysandbox.ui.client.view.SandboxedSdkView
 import androidx.privacysandbox.ui.core.DelegatingSandboxedUiAdapter
 import androidx.privacysandbox.ui.core.SandboxedUiAdapter
-import androidx.privacysandbox.ui.core.SessionConstants
+import androidx.privacysandbox.ui.core.SessionData
 import androidx.privacysandbox.ui.provider.AbstractSandboxedUiAdapter
 import com.runtimeenabled.R
 import com.runtimeenabled.api.SdkBannerRequest
@@ -63,7 +63,7 @@ class SdkSandboxedUiAdapterImpl(
      * We consider the client the owner of the SandboxedSdkView.
      *
      @param context The client's context.
-     * @param sessionConstants Constants related to the session, such as the presentation id.
+     * @param sessionData Constants related to the session, such as the presentation id.
      * @param initialWidth The initial width of the adapter's view.
      * @param initialHeight The initial height of the adapter's view.
      * @param isZOrderOnTop Whether the session's view should be drawn on top of other views.
@@ -72,7 +72,7 @@ class SdkSandboxedUiAdapterImpl(
      */
     override fun openSession(
         context: Context,
-        sessionConstants: SessionConstants,
+        sessionData: SessionData,
         initialWidth: Int,
         initialHeight: Int,
         isZOrderOnTop: Boolean,


### PR DESCRIPTION
This covers:

- Upgrade Kotlin and related dependencies to latest version available
- Gradle to 8.11.1, AGP 8.9.2
- UI Lib .15 signature change fixes
- Activity Lib .2 signature method name change to reflect managed/unmanaged activity
- RE Mediatee adapter now requires UI Client lib to have access to `SandboxedUiAdapterFactory`